### PR TITLE
feat(backend): Phase 5.2 Repository Layer

### DIFF
--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,38 @@
+"""
+Repository layer for database operations.
+
+This module provides the repository pattern implementation for data access,
+separating database operations from business logic.
+
+Repositories:
+    - BaseRepository: Generic CRUD operations for any model
+    - SessionRepository: ChatSession-specific operations
+    - MessageRepository: Message-specific operations
+
+Usage:
+    from app.repositories import SessionRepository, MessageRepository
+
+    async def example(db: AsyncSession):
+        session_repo = SessionRepository(db)
+        message_repo = MessageRepository(db)
+
+        # Get or create default session
+        default_session = await session_repo.get_or_create_default()
+
+        # Create a message
+        message = await message_repo.create_message(
+            session_id=default_session.id,
+            sender="user",
+            content="Hello!",
+        )
+"""
+
+from app.repositories.base import BaseRepository
+from app.repositories.message import MessageRepository
+from app.repositories.session import SessionRepository
+
+__all__ = [
+    "BaseRepository",
+    "SessionRepository",
+    "MessageRepository",
+]

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -1,0 +1,133 @@
+"""Base repository with generic CRUD operations."""
+
+import uuid
+from typing import Generic, TypeVar
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.base import Base
+
+# Generic type for SQLAlchemy models
+ModelType = TypeVar("ModelType", bound=Base)
+
+
+class BaseRepository(Generic[ModelType]):
+    """
+    Base repository providing common CRUD operations.
+
+    All repositories inherit from this class to get standard
+    database operations with async support.
+
+    Usage:
+        class UserRepository(BaseRepository[User]):
+            def __init__(self, session: AsyncSession):
+                super().__init__(User, session)
+    """
+
+    def __init__(self, model: type[ModelType], session: AsyncSession):
+        """
+        Initialize repository with model class and database session.
+
+        Args:
+            model: SQLAlchemy model class
+            session: Async database session
+        """
+        self.model = model
+        self.session = session
+
+    async def get_by_id(self, id: uuid.UUID) -> ModelType | None:
+        """
+        Get a single record by its ID.
+
+        Args:
+            id: UUID of the record
+
+        Returns:
+            Model instance or None if not found
+        """
+        result = await self.session.execute(select(self.model).where(self.model.id == id))
+        return result.scalar_one_or_none()
+
+    async def get_all(self, limit: int = 100, offset: int = 0) -> list[ModelType]:
+        """
+        Get all records with pagination.
+
+        Args:
+            limit: Maximum number of records to return
+            offset: Number of records to skip
+
+        Returns:
+            List of model instances
+        """
+        result = await self.session.execute(select(self.model).limit(limit).offset(offset))
+        return list(result.scalars().all())
+
+    async def create(self, **kwargs) -> ModelType:
+        """
+        Create a new record.
+
+        Args:
+            **kwargs: Model field values
+
+        Returns:
+            Created model instance
+        """
+        instance = self.model(**kwargs)
+        self.session.add(instance)
+        await self.session.flush()
+        await self.session.refresh(instance)
+        return instance
+
+    async def update(self, id: uuid.UUID, **kwargs) -> ModelType | None:
+        """
+        Update an existing record.
+
+        Args:
+            id: UUID of the record to update
+            **kwargs: Fields to update
+
+        Returns:
+            Updated model instance or None if not found
+        """
+        instance = await self.get_by_id(id)
+        if instance is None:
+            return None
+
+        for key, value in kwargs.items():
+            if hasattr(instance, key):
+                setattr(instance, key, value)
+
+        await self.session.flush()
+        await self.session.refresh(instance)
+        return instance
+
+    async def delete(self, id: uuid.UUID) -> bool:
+        """
+        Delete a record by ID.
+
+        Args:
+            id: UUID of the record to delete
+
+        Returns:
+            True if deleted, False if not found
+        """
+        instance = await self.get_by_id(id)
+        if instance is None:
+            return False
+
+        await self.session.delete(instance)
+        await self.session.flush()
+        return True
+
+    async def count(self) -> int:
+        """
+        Count total records.
+
+        Returns:
+            Total number of records
+        """
+        from sqlalchemy import func
+
+        result = await self.session.execute(select(func.count()).select_from(self.model))
+        return result.scalar_one()

--- a/backend/app/repositories/message.py
+++ b/backend/app/repositories/message.py
@@ -1,0 +1,176 @@
+"""Repository for Message operations."""
+
+import uuid
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.message import Message
+from app.repositories.base import BaseRepository
+
+# Valid sender types
+SenderType = Literal["user", "assistant"]
+
+
+class MessageRepository(BaseRepository[Message]):
+    """
+    Repository for Message database operations.
+
+    Extends BaseRepository with message-specific methods.
+    """
+
+    def __init__(self, session: AsyncSession):
+        """Initialize repository with database session."""
+        super().__init__(Message, session)
+
+    async def create_message(
+        self,
+        session_id: uuid.UUID,
+        sender: SenderType,
+        content: str,
+        meta: dict | None = None,
+    ) -> Message:
+        """
+        Create a new message in a session.
+
+        Args:
+            session_id: UUID of the chat session
+            sender: Who sent the message ('user' or 'assistant')
+            content: Message content text
+            meta: Optional metadata (e.g., AI provider info)
+
+        Returns:
+            Created Message instance
+        """
+        return await self.create(
+            session_id=session_id,
+            sender=sender,
+            content=content,
+            meta=meta or {},
+        )
+
+    async def get_by_session(
+        self,
+        session_id: uuid.UUID,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[Message]:
+        """
+        Get messages for a specific session with pagination.
+
+        Messages are ordered by creation time (oldest first).
+
+        Args:
+            session_id: UUID of the chat session
+            limit: Maximum number of messages to return
+            offset: Number of messages to skip
+
+        Returns:
+            List of Message instances
+        """
+        result = await self.session.execute(
+            select(Message)
+            .where(Message.session_id == session_id)
+            .order_by(Message.created_at.asc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return list(result.scalars().all())
+
+    async def get_recent(
+        self,
+        session_id: uuid.UUID,
+        limit: int = 10,
+    ) -> list[Message]:
+        """
+        Get the most recent messages from a session.
+
+        Useful for providing context to AI responses.
+        Returns messages in chronological order (oldest to newest).
+
+        Args:
+            session_id: UUID of the chat session
+            limit: Number of recent messages to return
+
+        Returns:
+            List of Message instances (chronological order)
+        """
+        # Subquery to get the most recent message IDs
+        # We order by created_at DESC to get recent, then reverse for chronological
+        result = await self.session.execute(
+            select(Message)
+            .where(Message.session_id == session_id)
+            .order_by(Message.created_at.desc())
+            .limit(limit)
+        )
+        messages = list(result.scalars().all())
+
+        # Reverse to get chronological order (oldest first)
+        return list(reversed(messages))
+
+    async def count_by_session(self, session_id: uuid.UUID) -> int:
+        """
+        Count messages in a specific session.
+
+        Args:
+            session_id: UUID of the chat session
+
+        Returns:
+            Number of messages in the session
+        """
+        from sqlalchemy import func
+
+        result = await self.session.execute(
+            select(func.count()).select_from(Message).where(Message.session_id == session_id)
+        )
+        return result.scalar_one()
+
+    async def get_last_user_message(self, session_id: uuid.UUID) -> Message | None:
+        """
+        Get the most recent user message from a session.
+
+        Useful for auto-generating session titles.
+
+        Args:
+            session_id: UUID of the chat session
+
+        Returns:
+            Most recent user Message or None
+        """
+        result = await self.session.execute(
+            select(Message)
+            .where(Message.session_id == session_id)
+            .where(Message.sender == "user")
+            .order_by(Message.created_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def to_conversation_history(
+        self,
+        session_id: uuid.UUID,
+        limit: int = 10,
+    ) -> list[dict]:
+        """
+        Get recent messages formatted for AI conversation context.
+
+        Returns messages in the format expected by the AI service:
+        [{"sender": "user", "content": "..."}, {"sender": "assistant", "content": "..."}]
+
+        Args:
+            session_id: UUID of the chat session
+            limit: Number of recent messages to include
+
+        Returns:
+            List of message dictionaries for AI context
+        """
+        messages = await self.get_recent(session_id, limit)
+        return [
+            {
+                "type": "message",
+                "sender": msg.sender,
+                "content": msg.content,
+            }
+            for msg in messages
+        ]

--- a/backend/app/repositories/session.py
+++ b/backend/app/repositories/session.py
@@ -1,0 +1,135 @@
+"""Repository for ChatSession operations."""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.session import ChatSession
+from app.repositories.base import BaseRepository
+
+# Default session identifier - used for the single global session
+DEFAULT_SESSION_TITLE = "Default Chat Session"
+DEFAULT_SESSION_META = {"is_default": True}
+
+
+class SessionRepository(BaseRepository[ChatSession]):
+    """
+    Repository for ChatSession database operations.
+
+    Extends BaseRepository with session-specific methods.
+    Following the "supersimple" approach with a single global session.
+    """
+
+    def __init__(self, session: AsyncSession):
+        """Initialize repository with database session."""
+        super().__init__(ChatSession, session)
+
+    async def get_or_create_default(self) -> ChatSession:
+        """
+        Get the default global session, creating it if it doesn't exist.
+
+        This is the primary method for Phase 5's single-session approach.
+        All messages go to this one shared session.
+
+        Returns:
+            The default ChatSession instance
+        """
+        # Try to find existing default session
+        result = await self.session.execute(
+            select(ChatSession).where(
+                ChatSession.meta["is_default"].as_boolean().is_(True)
+            )
+        )
+        default_session = result.scalar_one_or_none()
+
+        if default_session is not None:
+            return default_session
+
+        # Create default session if it doesn't exist
+        return await self.create(
+            title=DEFAULT_SESSION_TITLE,
+            meta=DEFAULT_SESSION_META,
+        )
+
+    async def get_with_messages(
+        self,
+        session_id: uuid.UUID,
+        message_limit: int | None = None,
+    ) -> ChatSession | None:
+        """
+        Get a session with its messages eagerly loaded.
+
+        Args:
+            session_id: UUID of the session
+            message_limit: Optional limit on number of messages to load
+
+        Returns:
+            ChatSession with messages loaded, or None if not found
+        """
+        query = select(ChatSession).where(ChatSession.id == session_id)
+
+        # Eagerly load messages
+        query = query.options(selectinload(ChatSession.messages))
+
+        result = await self.session.execute(query)
+        session = result.scalar_one_or_none()
+
+        # Apply message limit in Python (SQLAlchemy doesn't support LIMIT on relationships)
+        if session is not None and message_limit is not None:
+            # Messages are ordered by created_at in the relationship
+            session.messages = session.messages[-message_limit:]
+
+        return session
+
+    async def get_default_with_messages(
+        self,
+        message_limit: int = 50,
+    ) -> ChatSession:
+        """
+        Get the default session with recent messages loaded.
+
+        Convenience method combining get_or_create_default and get_with_messages.
+
+        Args:
+            message_limit: Number of recent messages to load (default: 50)
+
+        Returns:
+            Default ChatSession with messages loaded
+        """
+        # Ensure default session exists
+        default_session = await self.get_or_create_default()
+
+        # Reload with messages
+        session_with_messages = await self.get_with_messages(
+            default_session.id,
+            message_limit=message_limit,
+        )
+
+        # Should never be None since we just created/got it
+        return session_with_messages or default_session
+
+    async def update_title_from_message(
+        self,
+        session_id: uuid.UUID,
+        first_message: str,
+    ) -> ChatSession | None:
+        """
+        Update session title based on first message content.
+
+        Auto-generates a title from the first user message (first 50 chars).
+
+        Args:
+            session_id: UUID of the session
+            first_message: Content of the first message
+
+        Returns:
+            Updated ChatSession or None if not found
+        """
+        # Generate title from first message (max 50 chars)
+        title = first_message[:50].strip()
+        if len(first_message) > 50:
+            title += "..."
+
+        return await self.update(session_id, title=title)


### PR DESCRIPTION
## Summary

Implements Phase 5.2: Repository pattern for database operations.

Provides a clean abstraction layer between business logic and database access, following the repository pattern with full async support.

## Changes

### New Files

| File | Purpose |
|------|---------|
| `app/repositories/__init__.py` | Package exports |
| `app/repositories/base.py` | Generic CRUD operations |
| `app/repositories/session.py` | ChatSession operations |
| `app/repositories/message.py` | Message operations |

### BaseRepository

Generic repository with common CRUD operations:
- `get_by_id(id)` - Get record by UUID
- `get_all(limit, offset)` - Paginated list
- `create(**kwargs)` - Create new record
- `update(id, **kwargs)` - Update existing record
- `delete(id)` - Delete record
- `count()` - Total record count

### SessionRepository

Session-specific operations for the "single global session" approach:
- `get_or_create_default()` - Get/create the default session
- `get_with_messages(id, limit)` - Eager load with messages
- `get_default_with_messages(limit)` - Default session + messages
- `update_title_from_message(id, message)` - Auto-generate title

### MessageRepository

Message-specific operations:
- `create_message(session_id, sender, content, meta)` - Create message
- `get_by_session(session_id, limit, offset)` - Paginated messages
- `get_recent(session_id, limit)` - Recent messages (for AI context)
- `count_by_session(session_id)` - Count messages
- `get_last_user_message(session_id)` - Most recent user message
- `to_conversation_history(session_id, limit)` - Format for AI service

## Usage Example

```python
from app.repositories import SessionRepository, MessageRepository

async def handle_message(db: AsyncSession, content: str):
    session_repo = SessionRepository(db)
    message_repo = MessageRepository(db)
    
    # Get default session
    session = await session_repo.get_or_create_default()
    
    # Save user message
    await message_repo.create_message(
        session_id=session.id,
        sender="user",
        content=content,
    )
    
    # Get context for AI
    history = await message_repo.to_conversation_history(
        session_id=session.id,
        limit=10,
    )
```

## Design Decisions

- **Single global session** - Per Issue #14 review ("supersimple" approach)
- **Async-first** - All methods are async for SQLAlchemy 2.0 compatibility
- **Generic base** - BaseRepository uses Python generics for type safety
- **Clean separation** - Repositories don't contain business logic

## What's Next (Phase 5.3)

- [ ] Integrate repositories with WebSocket handler
- [ ] Persist messages on send
- [ ] Load history on connection
- [ ] Auto-create default session on startup

## Related

- Part of Issue #14 (Phase 5: Persistence & History)
- Builds on PR #32 (Phase 5.1 Database Foundation)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)