### PR TITLE
feat: Phase 5.3 - History API with message persistence

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,1 +1,5 @@
 """API routes package."""
+
+from app.api import history, websocket
+
+__all__ = ["history", "websocket"]

--- a/backend/app/api/history.py
+++ b/backend/app/api/history.py
@@ -1,0 +1,63 @@
+"""REST API endpoints for chat history."""
+
+import logging
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel
+
+from app.services.chat_service import chat_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api", tags=["history"])
+
+
+class MessageResponse(BaseModel):
+    """Response model for a single message."""
+
+    type: str
+    sender: str
+    content: str
+
+
+class HistoryResponse(BaseModel):
+    """Response model for chat history."""
+
+    messages: list[MessageResponse]
+    count: int
+
+
+@router.get("/history", response_model=HistoryResponse)
+async def get_history(
+    limit: int = Query(default=50, ge=1, le=100, description="Number of messages to return"),
+) -> HistoryResponse:
+    """
+    Get chat history from the default session.
+
+    Returns the most recent messages from the chat history,
+    ordered from oldest to newest.
+
+    Args:
+        limit: Maximum number of messages to return (1-100, default 50)
+
+    Returns:
+        HistoryResponse with list of messages and count
+    """
+    # Get or create session and load history
+    session_id, _ = await chat_service.get_or_create_session()
+
+    # Get history with pagination
+    history = await chat_service.get_conversation_history(session_id, limit=limit)
+
+    messages = [
+        MessageResponse(
+            type=msg.get("type", "message"),
+            sender=msg.get("sender", "unknown"),
+            content=msg.get("content", ""),
+        )
+        for msg in history
+    ]
+
+    logger.info(f"Retrieved {len(messages)} messages from history")
+
+    return HistoryResponse(messages=messages, count=len(messages))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,14 +1,36 @@
 """Main FastAPI application."""
 
+import logging
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import websocket
+from app.api import history, websocket
+from app.database import close_db, init_db
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan events for startup and shutdown."""
+    # Startup
+    logger.info("Initializing database...")
+    await init_db()
+    logger.info("Database initialized")
+    yield
+    # Shutdown
+    logger.info("Closing database connections...")
+    await close_db()
+    logger.info("Database connections closed")
+
 
 app = FastAPI(
     title="Stupid Chat Bot API",
     description="A simple, straightforward AI-powered chat application",
     version="0.1.0",
+    lifespan=lifespan,
 )
 
 # Configure CORS
@@ -22,6 +44,7 @@ app.add_middleware(
 
 # Include routers
 app.include_router(websocket.router)
+app.include_router(history.router)
 
 
 @app.get("/")

--- a/backend/app/repositories/session.py
+++ b/backend/app/repositories/session.py
@@ -38,9 +38,7 @@ class SessionRepository(BaseRepository[ChatSession]):
         """
         # Try to find existing default session
         result = await self.session.execute(
-            select(ChatSession).where(
-                ChatSession.meta["is_default"].as_boolean().is_(True)
-            )
+            select(ChatSession).where(ChatSession.meta["is_default"].as_boolean().is_(True))
         )
         default_session = result.scalar_one_or_none()
 

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,1 +1,6 @@
 """Services package."""
+
+from app.services.ai_service import ai_service
+from app.services.chat_service import chat_service
+
+__all__ = ["ai_service", "chat_service"]

--- a/backend/app/services/chat_service.py
+++ b/backend/app/services/chat_service.py
@@ -1,0 +1,150 @@
+"""Chat service for managing chat sessions and message persistence."""
+
+import logging
+import uuid
+
+from app.database import async_session_maker
+from app.repositories import MessageRepository, SessionRepository
+
+logger = logging.getLogger(__name__)
+
+
+class ChatService:
+    """
+    Service for chat operations with database persistence.
+
+    Handles session management and message storage for the chat application.
+    Uses the repository pattern for database operations.
+    """
+
+    async def get_or_create_session(self) -> tuple[uuid.UUID, list[dict]]:
+        """
+        Get or create the default chat session and load history.
+
+        Returns:
+            Tuple of (session_id, conversation_history)
+        """
+        async with async_session_maker() as db:
+            session_repo = SessionRepository(db)
+            message_repo = MessageRepository(db)
+
+            # Get or create default session
+            chat_session = await session_repo.get_or_create_default()
+
+            # Load recent conversation history
+            history = await message_repo.to_conversation_history(chat_session.id, limit=50)
+
+            await db.commit()
+
+            logger.info(f"Session {chat_session.id}: loaded {len(history)} messages from history")
+
+            return chat_session.id, history
+
+    async def save_user_message(
+        self,
+        session_id: uuid.UUID,
+        content: str,
+    ) -> uuid.UUID:
+        """
+        Save a user message to the database.
+
+        Args:
+            session_id: The chat session ID
+            content: Message content
+
+        Returns:
+            The created message ID
+        """
+        async with async_session_maker() as db:
+            message_repo = MessageRepository(db)
+
+            message = await message_repo.create_message(
+                session_id=session_id,
+                sender="user",
+                content=content,
+            )
+
+            await db.commit()
+
+            logger.debug(f"Saved user message {message.id} to session {session_id}")
+
+            return message.id
+
+    async def save_assistant_message(
+        self,
+        session_id: uuid.UUID,
+        content: str,
+        meta: dict | None = None,
+    ) -> uuid.UUID:
+        """
+        Save an assistant message to the database.
+
+        Args:
+            session_id: The chat session ID
+            content: Message content
+            meta: Optional metadata (e.g., AI provider info)
+
+        Returns:
+            The created message ID
+        """
+        async with async_session_maker() as db:
+            message_repo = MessageRepository(db)
+
+            message = await message_repo.create_message(
+                session_id=session_id,
+                sender="assistant",
+                content=content,
+                meta=meta,
+            )
+
+            await db.commit()
+
+            logger.debug(f"Saved assistant message {message.id} to session {session_id}")
+
+            return message.id
+
+    async def get_conversation_history(
+        self,
+        session_id: uuid.UUID,
+        limit: int = 50,
+    ) -> list[dict]:
+        """
+        Get conversation history for a session.
+
+        Args:
+            session_id: The chat session ID
+            limit: Maximum number of messages to return
+
+        Returns:
+            List of message dictionaries with sender and content
+        """
+        async with async_session_maker() as db:
+            message_repo = MessageRepository(db)
+
+            history = await message_repo.to_conversation_history(session_id, limit)
+
+            return history
+
+    async def get_recent_context(
+        self,
+        session_id: uuid.UUID,
+        limit: int = 10,
+    ) -> list[dict]:
+        """
+        Get recent messages for AI context.
+
+        Args:
+            session_id: The chat session ID
+            limit: Number of recent messages for context
+
+        Returns:
+            List of message dictionaries for AI context
+        """
+        async with async_session_maker() as db:
+            message_repo = MessageRepository(db)
+
+            return await message_repo.to_conversation_history(session_id, limit)
+
+
+# Global chat service instance
+chat_service = ChatService()


### PR DESCRIPTION
## Summary

Implements Phase 5.3 of Issue #14: History API with message persistence.

- Adds database persistence for all chat messages
- Loads chat history on WebSocket connection
- Provides REST endpoint for history retrieval

## Changes

### New Files

**`app/services/chat_service.py`**
- `ChatService` class with methods:
  - `get_or_create_session()` - Initialize session, load history
  - `save_user_message()` - Persist user messages
  - `save_assistant_message()` - Persist AI responses with metadata
  - `get_conversation_history()` - Retrieve history with limit

**`app/api/history.py`**
- `GET /api/history` endpoint
  - Query param: `limit` (1-100, default 50)
  - Returns messages with count
  - Appears in OpenAPI docs at `/docs`

### Modified Files

**`app/main.py`**
- Added `lifespan` context manager for database lifecycle
- Database initialized on startup
- Connections closed on shutdown

**`app/api/websocket.py`**
- Integrated with `chat_service` for persistence
- Session initialized on first connection
- History sent to connecting clients via `type: "history"` message
- User messages saved to database
- AI responses saved with provider/model metadata

## How It Works

1. **On app startup**: Database tables created/verified
2. **On WebSocket connect**: 
   - Default session loaded/created
   - History fetched from database
   - History sent to client as `{"type": "history", "messages": [...]}`
3. **On user message**: Saved to database, then processed
4. **On AI response**: Saved to database with metadata
5. **On app shutdown**: Database connections closed

## API Documentation

After merging, the history endpoint will appear at:
- Swagger UI: `http://localhost:8000/docs`
- ReDoc: `http://localhost:8000/redoc`

## Test Plan

- [ ] Start backend with `docker compose up`
- [ ] Connect to WebSocket - should receive history message
- [ ] Send a message - should be saved to database
- [ ] Refresh page - previous messages should appear
- [ ] Call `GET /api/history` - should return messages
- [ ] Check `data/chat.db` exists with data

## Next Steps (Phase 5.4)

- Session management (multiple conversations)
- Session switching
- Clear/delete conversation

Part of #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)