### PR TITLE
feat: implement Phase 5.5 Frontend session management UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,14 @@
+.app-container {
+  display: flex;
+  height: 100vh;
+  width: 100%;
+  background: var(--body-bg, #0f0f1a);
+}
+
 .app {
   display: flex;
   flex-direction: column;
+  flex: 1;
   height: 100vh;
   max-width: 1200px;
   margin: 0 auto;
@@ -11,6 +19,10 @@
 }
 
 @media (max-width: 768px) {
+  .app-container {
+    flex-direction: column;
+  }
+
   .app {
     max-width: 100%;
     height: 100vh;

--- a/frontend/src/components/SessionSidebar.css
+++ b/frontend/src/components/SessionSidebar.css
@@ -1,0 +1,163 @@
+.session-sidebar {
+  width: 260px;
+  min-width: 260px;
+  background: var(--sidebar-bg, #1a1a2e);
+  border-right: 1px solid var(--border-color, #2a2a4a);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid var(--border-color, #2a2a4a);
+}
+
+.sidebar-header h2 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary, #ffffff);
+}
+
+.new-chat-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color, #3a3a5a);
+  background: transparent;
+  color: var(--text-primary, #ffffff);
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.new-chat-btn:hover:not(:disabled) {
+  background: var(--hover-bg, #2a2a4a);
+  border-color: var(--accent-color, #6366f1);
+}
+
+.new-chat-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.session-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.session-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px;
+  margin-bottom: 4px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.session-item:hover {
+  background: var(--hover-bg, #2a2a4a);
+}
+
+.session-item.active {
+  background: var(--active-bg, #3a3a5a);
+  border-left: 3px solid var(--accent-color, #6366f1);
+}
+
+.session-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.session-title {
+  font-size: 0.9rem;
+  color: var(--text-primary, #ffffff);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-date {
+  font-size: 0.75rem;
+  color: var(--text-secondary, #888899);
+}
+
+.delete-btn {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary, #888899);
+  font-size: 0.9rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.session-item:hover .delete-btn {
+  opacity: 1;
+}
+
+.delete-btn:hover {
+  background: var(--danger-bg, #ff4444);
+  color: white;
+}
+
+.loading-sessions,
+.no-sessions {
+  text-align: center;
+  padding: 24px;
+  color: var(--text-secondary, #888899);
+  font-size: 0.9rem;
+}
+
+/* Scrollbar styling */
+.session-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.session-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.session-list::-webkit-scrollbar-thumb {
+  background: var(--border-color, #3a3a5a);
+  border-radius: 3px;
+}
+
+.session-list::-webkit-scrollbar-thumb:hover {
+  background: var(--text-secondary, #888899);
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .session-sidebar {
+    position: fixed;
+    left: -260px;
+    top: 0;
+    bottom: 0;
+    z-index: 100;
+    transition: left 0.3s ease;
+  }
+
+  .session-sidebar.open {
+    left: 0;
+  }
+}

--- a/frontend/src/components/SessionSidebar.jsx
+++ b/frontend/src/components/SessionSidebar.jsx
@@ -1,0 +1,125 @@
+import { useState } from 'react'
+import PropTypes from 'prop-types'
+import './SessionSidebar.css'
+
+function SessionSidebar({
+  sessions,
+  currentSessionId,
+  onSelectSession,
+  onCreateSession,
+  onDeleteSession,
+  isLoading,
+}) {
+  const [isCreating, setIsCreating] = useState(false)
+
+  const handleCreateClick = async () => {
+    setIsCreating(true)
+    try {
+      await onCreateSession()
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  const handleDeleteClick = (e, sessionId, isDefault) => {
+    e.stopPropagation()
+    if (isDefault) {
+      return // Cannot delete default session
+    }
+    if (window.confirm('Delete this conversation?')) {
+      onDeleteSession(sessionId)
+    }
+  }
+
+  const formatDate = dateString => {
+    const date = new Date(dateString)
+    const now = new Date()
+    const diffMs = now - date
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+    if (diffDays === 0) {
+      return 'Today'
+    } else if (diffDays === 1) {
+      return 'Yesterday'
+    } else if (diffDays < 7) {
+      return `${diffDays} days ago`
+    } else {
+      return date.toLocaleDateString()
+    }
+  }
+
+  return (
+    <aside className="session-sidebar">
+      <div className="sidebar-header">
+        <h2>Conversations</h2>
+        <button
+          className="new-chat-btn"
+          onClick={handleCreateClick}
+          disabled={isCreating}
+          title="New conversation"
+        >
+          {isCreating ? '...' : '+'}
+        </button>
+      </div>
+
+      <div className="session-list">
+        {isLoading ? (
+          <div className="loading-sessions">Loading...</div>
+        ) : sessions.length === 0 ? (
+          <div className="no-sessions">No conversations yet</div>
+        ) : (
+          sessions.map(session => {
+            const isDefault = session.metadata?.is_default
+            const isActive = session.id === currentSessionId
+            return (
+              <div
+                key={session.id}
+                className={`session-item ${isActive ? 'active' : ''}`}
+                onClick={() => onSelectSession(session.id)}
+              >
+                <div className="session-info">
+                  <span className="session-title" title={session.title}>
+                    {session.title}
+                  </span>
+                  <span className="session-date">{formatDate(session.updated_at)}</span>
+                </div>
+                {!isDefault && (
+                  <button
+                    className="delete-btn"
+                    onClick={e => handleDeleteClick(e, session.id, isDefault)}
+                    title="Delete conversation"
+                  >
+                    x
+                  </button>
+                )}
+              </div>
+            )
+          })
+        )}
+      </div>
+    </aside>
+  )
+}
+
+SessionSidebar.propTypes = {
+  sessions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      metadata: PropTypes.object,
+      updated_at: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  currentSessionId: PropTypes.string,
+  onSelectSession: PropTypes.func.isRequired,
+  onCreateSession: PropTypes.func.isRequired,
+  onDeleteSession: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool,
+}
+
+SessionSidebar.defaultProps = {
+  currentSessionId: null,
+  isLoading: false,
+}
+
+export default SessionSidebar

--- a/frontend/src/services/sessionsApi.js
+++ b/frontend/src/services/sessionsApi.js
@@ -1,0 +1,96 @@
+/**
+ * Sessions API service for REST endpoints
+ */
+
+const API_BASE = 'http://localhost:8000/api/sessions'
+
+/**
+ * Fetch all sessions
+ * @param {number} limit - Max sessions to return
+ * @param {number} offset - Pagination offset
+ * @returns {Promise<{sessions: Array, total: number}>}
+ */
+export async function fetchSessions(limit = 50, offset = 0) {
+  const response = await fetch(`${API_BASE}?limit=${limit}&offset=${offset}`)
+  if (!response.ok) {
+    throw new Error('Failed to fetch sessions')
+  }
+  return response.json()
+}
+
+/**
+ * Create a new session
+ * @param {string} title - Session title
+ * @returns {Promise<Object>} Created session
+ */
+export async function createSession(title = 'New Chat') {
+  const response = await fetch(API_BASE, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  })
+  if (!response.ok) {
+    throw new Error('Failed to create session')
+  }
+  return response.json()
+}
+
+/**
+ * Get a specific session
+ * @param {string} sessionId - Session UUID
+ * @returns {Promise<Object>} Session details
+ */
+export async function getSession(sessionId) {
+  const response = await fetch(`${API_BASE}/${sessionId}`)
+  if (!response.ok) {
+    throw new Error('Failed to get session')
+  }
+  return response.json()
+}
+
+/**
+ * Update session title
+ * @param {string} sessionId - Session UUID
+ * @param {string} title - New title
+ * @returns {Promise<Object>} Updated session
+ */
+export async function updateSession(sessionId, title) {
+  const response = await fetch(`${API_BASE}/${sessionId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  })
+  if (!response.ok) {
+    throw new Error('Failed to update session')
+  }
+  return response.json()
+}
+
+/**
+ * Delete a session
+ * @param {string} sessionId - Session UUID
+ * @returns {Promise<void>}
+ */
+export async function deleteSession(sessionId) {
+  const response = await fetch(`${API_BASE}/${sessionId}`, {
+    method: 'DELETE',
+  })
+  if (!response.ok) {
+    const data = await response.json()
+    throw new Error(data.detail || 'Failed to delete session')
+  }
+}
+
+/**
+ * Get session history
+ * @param {string} sessionId - Session UUID
+ * @param {number} limit - Max messages to return
+ * @returns {Promise<{messages: Array, count: number}>}
+ */
+export async function getSessionHistory(sessionId, limit = 50) {
+  const response = await fetch(`${API_BASE}/${sessionId}/history?limit=${limit}`)
+  if (!response.ok) {
+    throw new Error('Failed to get session history')
+  }
+  return response.json()
+}


### PR DESCRIPTION
## Summary

Implements Phase 5.5: Frontend history features with session sidebar and switching UI.

- Adds session sidebar component for listing/managing conversations
- Integrates WebSocket with session_id support for session-scoped messaging
- Adds REST API client for session CRUD operations
- Session switching clears messages and reconnects WebSocket

## New Files

| File | Description |
|------|-------------|
| `SessionSidebar.jsx` | Sidebar component with session list, create/delete buttons |
| `SessionSidebar.css` | Dark theme styles matching app design |
| `sessionsApi.js` | REST API service for session endpoints |

## Modified Files

| File | Changes |
|------|---------|
| `websocket.js` | Added `session_id` support, `switchSession()`, `getSessionId()` |
| `App.jsx` | Session state, sidebar integration, history handling |
| `App.css` | Container layout for sidebar + main chat area |

## Features

- Session list in left sidebar
- Create new conversation (+)
- Delete conversations (x) - except default
- Active session indicator
- History loads on session switch
- Dark theme consistent with app

## Test Plan

- [ ] App loads with session sidebar visible
- [ ] Sessions list populated from API
- [ ] Click session switches conversation
- [ ] New chat button creates session
- [ ] Delete removes non-default session
- [ ] History loads when switching sessions
- [ ] WebSocket reconnects with correct session_id

## Screenshots

The sidebar appears on the left with:
- "Conversations" header with + button
- List of sessions with title and date
- Active session highlighted
- Delete button on hover (non-default only)

Relates to #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)