### PR TITLE
fix: add seccomp:unconfined and Python-based health check

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,12 +16,16 @@ services:
       - .env
     volumes:
       - chat_data:/app/data
+    # Required for thread creation on older Docker/kernel versions
+    security_opt:
+      - seccomp:unconfined
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      # Use Python for health check (curl not available in slim image)
+      test: ["CMD", ".venv/bin/python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 10s
+      start_period: 15s
     networks:
       - stupidbot-network
 


### PR DESCRIPTION
## Summary

Fixes the production deployment failures on DigitalOcean droplet.

## Changes

### 1. `security_opt: seccomp:unconfined`

Disables Docker's seccomp syscall filtering for the backend container. This allows:
- Thread creation (`clone3` syscall) needed by `aiosqlite`
- Fixes: `RuntimeError: can't start new thread`

### 2. Python-based health check

**Before (broken):**
```yaml
test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
```

**After (works):**
```yaml
test: ["CMD", ".venv/bin/python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
```

`curl` is not installed in `python:3.12-slim` image. Using Python's stdlib `urllib` instead.

### 3. Increased `start_period` to 15s

Gives the app more time to initialize database before health checks start.

## Test Plan

On droplet:
```bash
cd /opt/stupidbot

# Get updated compose file
curl -o docker-compose.prod.yml https://raw.githubusercontent.com/dremdem/stupid_chat_bot/master/docker-compose.prod.yml

# Restart
docker compose -f docker-compose.prod.yml down
docker compose -f docker-compose.prod.yml up -d

# Check status
docker compose -f docker-compose.prod.yml ps
docker compose -f docker-compose.prod.yml logs -f
```

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)