### PR TITLE
feat: make frontend port configurable with default 3001

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -34,7 +34,7 @@ services:
     container_name: stupidbot-frontend
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "${FRONTEND_PORT:-3001}:3000"
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Makes frontend container port configurable via `FRONTEND_PORT` environment variable
- Changes default from 3000 to 3001 to avoid conflicts with other services
- Documents the environment variable and its usage

## Changes
- `docker-compose.prod.yml`: Changed port from `"3000:3000"` to `"${FRONTEND_PORT:-3001}:3000"`
- `docs/PLAN_DEPLOYMENT.md`:
  - Updated architecture diagram to show port 3001
  - Updated docker-compose example
  - Updated testing instructions
  - Updated troubleshooting commands
  - Updated host nginx config example
  - Added "Environment Variables" documentation section

## Usage
```bash
# Default (port 3001)
docker compose -f docker-compose.prod.yml up -d

# Custom port
FRONTEND_PORT=8080 docker compose -f docker-compose.prod.yml up -d
```

## Fixes
Resolves port conflict on production server where port 3000 is used by cv-profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)