### PR TITLE
fix: use relative URLs for API and WebSocket connections

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,27 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Proxy API requests to backend container
+    location /api/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Proxy WebSocket requests to backend container
+    location /ws/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 86400;
+    }
+
     # SPA routing - serve index.html for all routes
     location / {
         try_files $uri $uri/ /index.html;

--- a/frontend/src/services/sessionsApi.js
+++ b/frontend/src/services/sessionsApi.js
@@ -2,7 +2,8 @@
  * Sessions API service for REST endpoints
  */
 
-const API_BASE = 'http://localhost:8000/api/sessions'
+// Use relative URL - works in both dev (Vite proxy) and prod (nginx proxy)
+const API_BASE = '/api/sessions'
 
 /**
  * Fetch all sessions

--- a/frontend/src/services/websocket.js
+++ b/frontend/src/services/websocket.js
@@ -22,7 +22,9 @@ class WebSocketService {
    * @returns {string} WebSocket URL
    */
   buildUrl(sessionId = null) {
-    const baseUrl = 'ws://localhost:8000/ws/chat'
+    // Use relative URL - works in both dev (Vite proxy) and prod (nginx proxy)
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const baseUrl = `${protocol}//${window.location.host}/ws/chat`
     if (sessionId) {
       return `${baseUrl}?session_id=${sessionId}`
     }


### PR DESCRIPTION
## Summary

Fixes the production deployment issue where frontend tries to connect to `localhost:8000` instead of the actual backend server.

- Replace hardcoded `localhost:8000` URLs with relative URLs
- Add nginx proxy configuration to route API/WebSocket requests to backend container
- Automatic protocol detection (ws/wss) for secure deployments

Fixes #50

## Problem

The frontend had hardcoded URLs:
- `websocket.js:25` → `ws://localhost:8000/ws/chat`
- `sessionsApi.js:5` → `http://localhost:8000/api/sessions`

When accessing from browser at `http://164.90.187.183:3001`, `localhost` referred to the user's machine, causing `ERR_CONNECTION_REFUSED`.

## Solution

### 1. websocket.js - Dynamic WebSocket URL
```javascript
// Before
const baseUrl = 'ws://localhost:8000/ws/chat'

// After
const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
const baseUrl = `${protocol}//${window.location.host}/ws/chat`
```

### 2. sessionsApi.js - Relative API URL
```javascript
// Before
const API_BASE = 'http://localhost:8000/api/sessions'

// After
const API_BASE = '/api/sessions'
```

### 3. nginx.conf - Proxy Configuration
Added reverse proxy to forward `/api/*` and `/ws/*` to backend container:
```nginx
location /api/ {
    proxy_pass http://backend:8000;
    # ... headers
}

location /ws/ {
    proxy_pass http://backend:8000;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    # ... headers
}
```

Uses Docker DNS (`backend:8000`) for container-to-container communication.

## Benefits

- ✅ Works in development (Vite proxy handles `/api` and `/ws`)
- ✅ Works in production (nginx proxy handles `/api` and `/ws`)
- ✅ Works behind host nginx reverse proxy (future Phase 5)
- ✅ Automatic HTTPS → WSS for secure deployments
- ✅ No rebuild needed for different environments

## Deployment Steps

After merging:
1. Trigger GitHub Actions workflow "Build and Push to GHCR"
2. On droplet:
   ```bash
   cd /opt/stupidbot
   docker compose -f docker-compose.prod.yml pull
   docker compose -f docker-compose.prod.yml up -d
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)