### PR TITLE
feat(auth): Phase 1 - Database Schema for OAuth Authentication

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -16,6 +16,8 @@ from app.models.base import Base
 # Import models to register them with Base.metadata
 from app.models.message import Message  # noqa: F401
 from app.models.session import ChatSession  # noqa: F401
+from app.models.user import User  # noqa: F401
+from app.models.user_session import UserSession  # noqa: F401
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/backend/alembic/versions/b2c3d4e5f6a7_add_users_and_user_sessions_tables.py
+++ b/backend/alembic/versions/b2c3d4e5f6a7_add_users_and_user_sessions_tables.py
@@ -1,0 +1,107 @@
+"""Add users and user_sessions tables for OAuth authentication
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2025-12-23 18:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create users table
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=True),
+        sa.Column("password_hash", sa.String(length=255), nullable=True),
+        sa.Column("provider", sa.String(length=20), nullable=False, server_default="email"),
+        sa.Column("provider_id", sa.String(length=255), nullable=True),
+        sa.Column("display_name", sa.String(length=100), nullable=True),
+        sa.Column("avatar_url", sa.String(length=500), nullable=True),
+        sa.Column("role", sa.String(length=20), nullable=False, server_default="user"),
+        sa.Column("message_limit", sa.Integer(), nullable=True),
+        sa.Column("context_window_size", sa.Integer(), nullable=False, server_default="20"),
+        sa.Column("is_blocked", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("is_email_verified", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("email"),
+    )
+    op.create_index(op.f("ix_users_email"), "users", ["email"], unique=True)
+    op.create_index(op.f("ix_users_provider_id"), "users", ["provider_id"], unique=False)
+    op.create_index(op.f("ix_users_role"), "users", ["role"], unique=False)
+
+    # Create user_sessions table (for JWT refresh tokens)
+    op.create_table(
+        "user_sessions",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("refresh_token_hash", sa.String(length=255), nullable=False),
+        sa.Column("user_agent", sa.String(length=500), nullable=True),
+        sa.Column("ip_address", sa.String(length=45), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
+            nullable=False,
+        ),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("refresh_token_hash"),
+    )
+    op.create_index(op.f("ix_user_sessions_user_id"), "user_sessions", ["user_id"], unique=False)
+
+    # Add user_id foreign key to messages table (using batch for SQLite)
+    with op.batch_alter_table("messages", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("user_id", sa.Uuid(), nullable=True))
+        batch_op.create_index(op.f("ix_messages_user_id"), ["user_id"], unique=False)
+        batch_op.create_foreign_key(
+            "fk_messages_user_id",
+            "users",
+            ["user_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    # Remove user_id from messages (using batch for SQLite)
+    with op.batch_alter_table("messages", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_messages_user_id", type_="foreignkey")
+        batch_op.drop_index(op.f("ix_messages_user_id"))
+        batch_op.drop_column("user_id")
+
+    # Drop user_sessions table
+    op.drop_index(op.f("ix_user_sessions_user_id"), table_name="user_sessions")
+    op.drop_table("user_sessions")
+
+    # Drop users table
+    op.drop_index(op.f("ix_users_role"), table_name="users")
+    op.drop_index(op.f("ix_users_provider_id"), table_name="users")
+    op.drop_index(op.f("ix_users_email"), table_name="users")
+    op.drop_table("users")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,5 +3,16 @@
 from app.models.base import Base, TimestampMixin
 from app.models.message import Message
 from app.models.session import ChatSession
+from app.models.user import AuthProvider, User, UserRole
+from app.models.user_session import UserSession
 
-__all__ = ["Base", "TimestampMixin", "ChatSession", "Message"]
+__all__ = [
+    "Base",
+    "TimestampMixin",
+    "ChatSession",
+    "Message",
+    "User",
+    "UserRole",
+    "AuthProvider",
+    "UserSession",
+]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,191 @@
+"""User model for authentication and authorization."""
+
+import uuid
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, Integer, String, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.user_session import UserSession
+
+
+class UserRole(str, Enum):
+    """User role enumeration for access control."""
+
+    ANONYMOUS = "anonymous"
+    USER = "user"
+    UNLIMITED = "unlimited"
+    ADMIN = "admin"
+
+
+class AuthProvider(str, Enum):
+    """Authentication provider enumeration."""
+
+    EMAIL = "email"
+    GOOGLE = "google"
+    GITHUB = "github"
+    FACEBOOK = "facebook"
+
+
+class User(Base, TimestampMixin):
+    """
+    Represents an authenticated user in the system.
+
+    Users can authenticate via OAuth providers (Google, GitHub, Facebook)
+    or email/password. Each user has a role that determines their access level.
+    """
+
+    __tablename__ = "users"
+
+    # Primary key
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        primary_key=True,
+        default=uuid.uuid4,
+        nullable=False,
+    )
+
+    # Authentication fields
+    email: Mapped[str | None] = mapped_column(
+        String(255),
+        unique=True,
+        nullable=True,
+        index=True,
+    )
+
+    password_hash: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+    )
+
+    # OAuth provider information
+    provider: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=AuthProvider.EMAIL.value,
+    )
+
+    provider_id: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+        index=True,
+    )
+
+    # Profile information
+    display_name: Mapped[str | None] = mapped_column(
+        String(100),
+        nullable=True,
+    )
+
+    avatar_url: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+    )
+
+    # Authorization
+    role: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=UserRole.USER.value,
+        index=True,
+    )
+
+    # Message limits (nullable = use default from tier)
+    message_limit: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+    )
+
+    # AI context window size (default: 20 messages)
+    context_window_size: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=20,
+    )
+
+    # Account status
+    is_blocked: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+    )
+
+    is_email_verified: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+    )
+
+    # Relationships
+    auth_sessions: Mapped[list["UserSession"]] = relationship(
+        "UserSession",
+        back_populates="user",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        """String representation of the user."""
+        return f"<User(id={self.id}, email={self.email}, role={self.role})>"
+
+    def to_dict(self, include_sensitive: bool = False) -> dict:
+        """Convert user to dictionary for API responses.
+
+        Args:
+            include_sensitive: If True, includes email and provider info.
+        """
+        result = {
+            "id": str(self.id),
+            "display_name": self.display_name,
+            "avatar_url": self.avatar_url,
+            "role": self.role,
+            "context_window_size": self.context_window_size,
+            "is_blocked": self.is_blocked,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        }
+
+        if include_sensitive:
+            result.update(
+                {
+                    "email": self.email,
+                    "provider": self.provider,
+                    "is_email_verified": self.is_email_verified,
+                    "message_limit": self.message_limit,
+                }
+            )
+
+        return result
+
+    @property
+    def is_admin(self) -> bool:
+        """Check if user has admin role."""
+        return self.role == UserRole.ADMIN.value
+
+    @property
+    def has_unlimited_messages(self) -> bool:
+        """Check if user has unlimited message access."""
+        return self.role in (UserRole.UNLIMITED.value, UserRole.ADMIN.value)
+
+    def get_effective_message_limit(self) -> int | None:
+        """Get the effective message limit for this user.
+
+        Returns:
+            Message limit or None if unlimited.
+        """
+        if self.has_unlimited_messages:
+            return None
+
+        if self.message_limit is not None:
+            return self.message_limit
+
+        # Default limits by role
+        if self.role == UserRole.USER.value:
+            return 30
+        elif self.role == UserRole.ANONYMOUS.value:
+            return 5
+
+        return None

--- a/backend/app/models/user_session.py
+++ b/backend/app/models/user_session.py
@@ -1,0 +1,104 @@
+"""UserSession model for storing authentication sessions (JWT refresh tokens)."""
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, String, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+class UserSession(Base):
+    """
+    Represents an authentication session for JWT refresh token management.
+
+    Each session stores a hashed refresh token and its expiration.
+    Users can have multiple active sessions (e.g., different devices).
+
+    Note: This is different from ChatSession, which stores conversation history.
+    """
+
+    __tablename__ = "user_sessions"
+
+    # Primary key
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        primary_key=True,
+        default=uuid.uuid4,
+        nullable=False,
+    )
+
+    # Foreign key to user
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # Refresh token (hashed for security)
+    refresh_token_hash: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        unique=True,
+    )
+
+    # Session metadata
+    user_agent: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+    )
+
+    ip_address: Mapped[str | None] = mapped_column(
+        String(45),  # IPv6 max length
+        nullable=True,
+    )
+
+    # Timestamps
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=datetime.utcnow,
+    )
+
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    # Relationships
+    user: Mapped["User"] = relationship(
+        "User",
+        back_populates="auth_sessions",
+    )
+
+    def __repr__(self) -> str:
+        """String representation of the session."""
+        return f"<UserSession(id={self.id}, user_id={self.user_id}, expires_at={self.expires_at})>"
+
+    def to_dict(self) -> dict:
+        """Convert session to dictionary for API responses."""
+        return {
+            "id": str(self.id),
+            "user_id": str(self.user_id),
+            "user_agent": self.user_agent,
+            "ip_address": self.ip_address,
+            "expires_at": self.expires_at.isoformat(),
+            "created_at": self.created_at.isoformat(),
+            "last_used_at": self.last_used_at.isoformat() if self.last_used_at else None,
+        }
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if the session has expired."""
+        return datetime.utcnow() > self.expires_at.replace(tzinfo=None)

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,21 @@
+"""Pydantic schemas for API request/response validation."""
+
+from app.schemas.user import (
+    UserBase,
+    UserCreate,
+    UserInDB,
+    UserPublic,
+    UserResponse,
+    UserRole,
+    UserUpdate,
+)
+
+__all__ = [
+    "UserBase",
+    "UserCreate",
+    "UserInDB",
+    "UserPublic",
+    "UserResponse",
+    "UserRole",
+    "UserUpdate",
+]

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,0 +1,145 @@
+"""Pydantic schemas for User-related API operations."""
+
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+class UserRole(str, Enum):
+    """User role enumeration for access control."""
+
+    ANONYMOUS = "anonymous"
+    USER = "user"
+    UNLIMITED = "unlimited"
+    ADMIN = "admin"
+
+
+class AuthProvider(str, Enum):
+    """Authentication provider enumeration."""
+
+    EMAIL = "email"
+    GOOGLE = "google"
+    GITHUB = "github"
+    FACEBOOK = "facebook"
+
+
+# --- Base Schemas ---
+
+
+class UserBase(BaseModel):
+    """Base schema with common user fields."""
+
+    email: EmailStr | None = None
+    display_name: str | None = Field(None, max_length=100)
+    avatar_url: str | None = Field(None, max_length=500)
+
+
+class UserCreate(UserBase):
+    """Schema for creating a new user via email registration."""
+
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=100)
+    display_name: str | None = Field(None, max_length=100)
+
+
+class UserCreateOAuth(BaseModel):
+    """Schema for creating a user via OAuth provider."""
+
+    email: EmailStr | None = None
+    display_name: str | None = Field(None, max_length=100)
+    avatar_url: str | None = Field(None, max_length=500)
+    provider: AuthProvider
+    provider_id: str
+
+
+class UserUpdate(BaseModel):
+    """Schema for updating user profile."""
+
+    display_name: str | None = Field(None, max_length=100)
+    avatar_url: str | None = Field(None, max_length=500)
+
+
+class UserUpdateAdmin(BaseModel):
+    """Schema for admin updating any user field."""
+
+    display_name: str | None = Field(None, max_length=100)
+    avatar_url: str | None = Field(None, max_length=500)
+    role: UserRole | None = None
+    message_limit: int | None = Field(None, ge=0)
+    context_window_size: int | None = Field(None, ge=1, le=100)
+    is_blocked: bool | None = None
+
+
+# --- Response Schemas ---
+
+
+class UserPublic(BaseModel):
+    """Public user info visible to other users."""
+
+    id: UUID
+    display_name: str | None
+    avatar_url: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserResponse(BaseModel):
+    """User info returned in API responses (for authenticated user)."""
+
+    id: UUID
+    email: str | None
+    display_name: str | None
+    avatar_url: str | None
+    provider: str
+    role: str
+    message_limit: int | None
+    context_window_size: int
+    is_blocked: bool
+    is_email_verified: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserInDB(UserResponse):
+    """User schema with all database fields (internal use only)."""
+
+    password_hash: str | None
+    provider_id: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# --- Admin Schemas ---
+
+
+class UserAdminResponse(UserResponse):
+    """Extended user info for admin views."""
+
+    provider_id: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserListResponse(BaseModel):
+    """Response for paginated user list."""
+
+    users: list[UserAdminResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+# --- Message Limit Schemas ---
+
+
+class MessageLimitInfo(BaseModel):
+    """Information about user's message limits."""
+
+    limit: int | None  # None means unlimited
+    used: int
+    remaining: int | None  # None means unlimited
+    is_unlimited: bool

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0.23",
     "aiosqlite>=0.19.0",
     "alembic>=1.13.0",
+    # Authentication (Issue #56)
+    "email-validator>=2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -385,6 +385,28 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.123.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1752,6 +1774,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "alembic" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "litellm" },
     { name = "pydantic" },
@@ -1790,6 +1813,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "black", marker = "extra == 'dev'", specifier = "==24.10.0" },
     { name = "black", marker = "extra == 'dev-local'", specifier = "==24.10.0" },
+    { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.5" },
     { name = "invoke", marker = "extra == 'dev'", specifier = ">=2.2.0" },
     { name = "invoke", marker = "extra == 'dev-local'", specifier = ">=2.2.0" },


### PR DESCRIPTION
## Summary

Implements **Phase 1: Database Schema & User Model** from the [OAuth 2.0 Implementation Plan](docs/oauth-implementation-plan.md).

This PR adds the foundational database models and schemas needed for the authentication system.

## Changes

### New Models

| Model | Description |
|-------|-------------|
| `User` | Stores authenticated users with OAuth/email credentials, roles, and limits |
| `UserSession` | Stores JWT refresh tokens for authentication sessions |

### Schema Changes

- **users table**: id, email, password_hash, provider, provider_id, display_name, avatar_url, role, message_limit, context_window_size, is_blocked, is_email_verified, timestamps
- **user_sessions table**: id, user_id (FK), refresh_token_hash, user_agent, ip_address, expires_at, timestamps
- **messages table**: Added `user_id` foreign key for message counting per user

### User Roles

| Role | Message Limit | Description |
|------|---------------|-------------|
| `anonymous` | 5 | Unauthenticated users |
| `user` | 30 | Authenticated users |
| `unlimited` | None | Admin-granted unlimited access |
| `admin` | None | Full access + user management |

### New Pydantic Schemas

- `UserCreate`, `UserCreateOAuth` - User registration
- `UserResponse`, `UserPublic` - API responses
- `UserUpdate`, `UserUpdateAdmin` - Profile updates
- `UserRole`, `AuthProvider` - Enums

### Dependencies

- Added `email-validator>=2.0.0` for Pydantic EmailStr support

## Migration

```
b2c3d4e5f6a7: Add users and user_sessions tables for OAuth authentication
```

Uses batch mode for SQLite compatibility when adding foreign key to messages.

## Testing

- [x] Models import correctly
- [x] Schemas import correctly
- [x] Migration runs successfully (upgrade)
- [x] Migration rollback works (downgrade)

## Related

- Issue: #56
- Implementation Plan: [oauth-implementation-plan.md](docs/oauth-implementation-plan.md)
- Next: Phase 2 - Message Limits & Anonymous Users

🤖 Generated with [Claude Code](https://claude.com/claude-code)