### PR TITLE
feat: add database statistics CLI command

### DIFF
--- a/backend/app/cli/__init__.py
+++ b/backend/app/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI modules for the Stupid Chat Bot backend."""

--- a/backend/app/cli/stats.py
+++ b/backend/app/cli/stats.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+"""
+CLI tool for displaying database statistics.
+
+Usage:
+    # Local development
+    cd backend && uv run python -m app.cli.stats
+
+    # Via invoke
+    cd backend && invoke db-stats
+
+    # Via make
+    make backend-db-stats
+
+    # Production (Docker)
+    docker exec stupidbot-backend .venv/bin/python -m app.cli.stats
+
+    # With time filter
+    python -m app.cli.stats --days 7
+"""
+
+import argparse
+import asyncio
+import sys
+from datetime import datetime
+
+from app.database import async_session_maker, close_db
+from app.repositories.stats import StatsRepository
+
+
+def format_datetime(iso_string: str | None) -> str:
+    """Format ISO datetime string for display."""
+    if not iso_string:
+        return "N/A"
+    try:
+        dt = datetime.fromisoformat(iso_string.replace("Z", "+00:00"))
+        return dt.strftime("%Y-%m-%d %H:%M")
+    except (ValueError, AttributeError):
+        return iso_string[:16] if iso_string else "N/A"
+
+
+def print_stats(stats: dict) -> None:
+    """Print statistics in a formatted way."""
+    width = 60
+
+    # Header
+    print("=" * width)
+    if stats.get("filter_days"):
+        print(f"       DATABASE STATISTICS (Last {stats['filter_days']} days)")
+    else:
+        print("              DATABASE STATISTICS")
+    print("=" * width)
+
+    # User counts
+    uc = stats["user_counts"]
+    print("\n USER COUNTS")
+    print(f"   Registered users:     {uc['registered_users']}")
+    print(f"   Unique session owners:{uc['unique_session_owners']}")
+    print(f"   Total chat sessions:  {uc['total_chat_sessions']}")
+
+    # Users by role
+    roles = stats["users_by_role"]
+    if roles:
+        print("\n USERS BY ROLE")
+        for r in roles:
+            print(f"   {r['role']:<15} {r['count']}")
+    else:
+        print("\n USERS BY ROLE")
+        print("   No registered users")
+
+    # Top active users
+    top_users = stats["top_active_users"]
+    print("\n TOP 5 ACTIVE USERS (by messages)")
+    if top_users:
+        for i, u in enumerate(top_users, 1):
+            identifier = u["identifier"][:30]
+            msg_count = u["message_count"]
+            user_type = u["user_type"]
+            type_marker = "" if user_type == "registered" else " [anon]"
+            print(f"   {i}. {identifier:<30} {msg_count:>5} msgs{type_marker}")
+    else:
+        print("   No messages found")
+
+    # Recent users
+    recent = stats["recent_users"]
+    print("\n LAST 5 REGISTERED USERS")
+    if recent:
+        for i, u in enumerate(recent, 1):
+            identifier = u["email"] or u["display_name"] or u["id"][:8]
+            identifier = identifier[:30]
+            date = format_datetime(u["created_at"])
+            print(f"   {i}. {identifier:<30} {date}")
+    else:
+        print("   No registered users")
+
+    # Message stats
+    ms = stats["message_stats"]
+    print("\n MESSAGE STATISTICS")
+    print(f"   Total messages:       {ms['total_messages']}")
+    print(f"   User messages:        {ms['user_messages']}")
+    print(f"   Assistant messages:   {ms['assistant_messages']}")
+    print(f"   Messages today:       {ms['messages_today']}")
+    print(f"   Avg per session:      {ms['avg_per_session']}")
+
+    # Session stats
+    ss = stats["session_stats"]
+    print("\n SESSION STATISTICS")
+    print(f"   Total sessions:       {ss['total_sessions']}")
+    print(f"   Active today:         {ss['active_today']}")
+    print(f"   Unique owners:        {ss['unique_owners']}")
+
+    print("\n" + "=" * width)
+
+
+async def main(days: int | None = None) -> int:
+    """
+    Main entry point for the stats CLI.
+
+    Args:
+        days: If provided, limit stats to last N days
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    try:
+        async with async_session_maker() as session:
+            repo = StatsRepository(session)
+            stats = await repo.get_all_stats(days)
+            print_stats(stats)
+        return 0
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    finally:
+        # Properly close the database engine to avoid hanging
+        await close_db()
+
+
+def run() -> None:
+    """CLI entry point with argument parsing."""
+    parser = argparse.ArgumentParser(
+        description="Display database statistics for Stupid Chat Bot",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+    python -m app.cli.stats           # All-time statistics
+    python -m app.cli.stats --days 7  # Last 7 days only
+    python -m app.cli.stats -d 30     # Last 30 days
+        """,
+    )
+    parser.add_argument(
+        "-d",
+        "--days",
+        type=int,
+        default=None,
+        help="Limit statistics to last N days (default: unlimited)",
+    )
+
+    args = parser.parse_args()
+    exit_code = asyncio.run(main(args.days))
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    run()

--- a/backend/app/repositories/stats.py
+++ b/backend/app/repositories/stats.py
@@ -1,0 +1,334 @@
+"""Repository for database statistics queries."""
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.message import Message
+from app.models.session import ChatSession
+from app.models.user import User
+
+
+class StatsRepository:
+    """
+    Repository for gathering database statistics.
+
+    Provides methods to query aggregate statistics about users,
+    sessions, and messages without inheriting from BaseRepository
+    since it doesn't operate on a single model.
+    """
+
+    def __init__(self, session: AsyncSession):
+        """Initialize repository with database session."""
+        self.session = session
+
+    async def get_user_counts(self, days: int | None = None) -> dict:
+        """
+        Get counts of registered users vs anonymous session owners.
+
+        Args:
+            days: If provided, only count users/sessions created within last N days
+
+        Returns:
+            Dictionary with user count statistics
+        """
+        date_filter = None
+        if days is not None:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+            date_filter = cutoff
+
+        # Count registered users
+        user_query = select(func.count()).select_from(User)
+        if date_filter:
+            user_query = user_query.where(User.created_at >= date_filter)
+        result = await self.session.execute(user_query)
+        registered_users = result.scalar_one()
+
+        # Count unique session owners (user_id strings from cookies)
+        session_query = select(func.count(func.distinct(ChatSession.user_id)))
+        if date_filter:
+            session_query = session_query.where(ChatSession.created_at >= date_filter)
+        result = await self.session.execute(session_query)
+        unique_session_owners = result.scalar_one()
+
+        # Count total chat sessions
+        total_sessions_query = select(func.count()).select_from(ChatSession)
+        if date_filter:
+            total_sessions_query = total_sessions_query.where(ChatSession.created_at >= date_filter)
+        result = await self.session.execute(total_sessions_query)
+        total_sessions = result.scalar_one()
+
+        return {
+            "registered_users": registered_users,
+            "unique_session_owners": unique_session_owners,
+            "total_chat_sessions": total_sessions,
+        }
+
+    async def get_users_by_role(self, days: int | None = None) -> list[dict]:
+        """
+        Get count of users grouped by role.
+
+        Args:
+            days: If provided, only count users created within last N days
+
+        Returns:
+            List of dicts with role and count
+        """
+        query = select(User.role, func.count(User.id).label("count")).group_by(User.role)
+
+        if days is not None:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+            query = query.where(User.created_at >= cutoff)
+
+        query = query.order_by(func.count(User.id).desc())
+        result = await self.session.execute(query)
+
+        return [{"role": row.role, "count": row.count} for row in result.all()]
+
+    async def get_top_active_users(self, limit: int = 5, days: int | None = None) -> list[dict]:
+        """
+        Get users with most messages sent.
+
+        Includes both registered users (by user_id FK in messages)
+        and anonymous session owners (by session's user_id).
+
+        Args:
+            limit: Number of top users to return
+            days: If provided, only count messages from last N days
+
+        Returns:
+            List of dicts with user info and message count
+        """
+        # For registered users: count messages where user_id is set
+        registered_query = (
+            select(
+                User.id,
+                User.email,
+                User.display_name,
+                func.count(Message.id).label("message_count"),
+                text("'registered' as user_type"),
+            )
+            .join(Message, Message.user_id == User.id)
+            .where(Message.sender == "user")
+            .group_by(User.id)
+        )
+
+        if days is not None:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+            registered_query = registered_query.where(Message.created_at >= cutoff)
+
+        result = await self.session.execute(
+            registered_query.order_by(func.count(Message.id).desc()).limit(limit)
+        )
+        registered_users = result.all()
+
+        # For anonymous: count user messages by session owner
+        # (messages where user_id is NULL, grouped by session's user_id)
+        anonymous_query = (
+            select(
+                ChatSession.user_id.label("session_owner"),
+                func.count(Message.id).label("message_count"),
+            )
+            .join(Message, Message.session_id == ChatSession.id)
+            .where(Message.sender == "user")
+            .where(Message.user_id.is_(None))
+            .group_by(ChatSession.user_id)
+        )
+
+        if days is not None:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+            anonymous_query = anonymous_query.where(Message.created_at >= cutoff)
+
+        result = await self.session.execute(
+            anonymous_query.order_by(func.count(Message.id).desc()).limit(limit)
+        )
+        anonymous_sessions = result.all()
+
+        # Combine and sort
+        combined = []
+
+        for row in registered_users:
+            combined.append(
+                {
+                    "identifier": row.email or row.display_name or str(row.id)[:8],
+                    "display_name": row.display_name,
+                    "message_count": row.message_count,
+                    "user_type": "registered",
+                }
+            )
+
+        for row in anonymous_sessions:
+            combined.append(
+                {
+                    "identifier": f"Anonymous ({row.session_owner[:8]}...)",
+                    "display_name": None,
+                    "message_count": row.message_count,
+                    "user_type": "anonymous",
+                }
+            )
+
+        # Sort by message count and take top N
+        combined.sort(key=lambda x: x["message_count"], reverse=True)
+        return combined[:limit]
+
+    async def get_recent_users(self, limit: int = 5, days: int | None = None) -> list[dict]:
+        """
+        Get most recently registered users.
+
+        Args:
+            limit: Number of users to return
+            days: If provided, only include users from last N days
+
+        Returns:
+            List of dicts with user info and registration date
+        """
+        query = select(
+            User.id,
+            User.email,
+            User.display_name,
+            User.role,
+            User.provider,
+            User.created_at,
+        ).order_by(User.created_at.desc())
+
+        if days is not None:
+            cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+            query = query.where(User.created_at >= cutoff)
+
+        result = await self.session.execute(query.limit(limit))
+
+        return [
+            {
+                "id": str(row.id),
+                "email": row.email,
+                "display_name": row.display_name,
+                "role": row.role,
+                "provider": row.provider,
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+            }
+            for row in result.all()
+        ]
+
+    async def get_message_stats(self, days: int | None = None) -> dict:
+        """
+        Get message statistics.
+
+        Args:
+            days: If provided, only include messages from last N days
+
+        Returns:
+            Dictionary with message statistics
+        """
+        date_filter = None
+        if days is not None:
+            date_filter = datetime.now(timezone.utc) - timedelta(days=days)
+
+        # Total messages
+        total_query = select(func.count()).select_from(Message)
+        if date_filter:
+            total_query = total_query.where(Message.created_at >= date_filter)
+        result = await self.session.execute(total_query)
+        total_messages = result.scalar_one()
+
+        # Messages by sender type
+        by_sender_query = select(Message.sender, func.count(Message.id).label("count")).group_by(
+            Message.sender
+        )
+        if date_filter:
+            by_sender_query = by_sender_query.where(Message.created_at >= date_filter)
+        result = await self.session.execute(by_sender_query)
+        by_sender = {row.sender: row.count for row in result.all()}
+
+        # Messages today
+        today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        result = await self.session.execute(
+            select(func.count()).select_from(Message).where(Message.created_at >= today_start)
+        )
+        messages_today = result.scalar_one()
+
+        # Average messages per session (for sessions with messages)
+        avg_query = text(
+            """
+            SELECT AVG(msg_count) as avg_per_session
+            FROM (
+                SELECT session_id, COUNT(*) as msg_count
+                FROM messages
+                GROUP BY session_id
+            )
+            """
+        )
+        result = await self.session.execute(avg_query)
+        row = result.fetchone()
+        avg_per_session = round(row[0], 1) if row and row[0] else 0
+
+        return {
+            "total_messages": total_messages,
+            "user_messages": by_sender.get("user", 0),
+            "assistant_messages": by_sender.get("assistant", 0),
+            "messages_today": messages_today,
+            "avg_per_session": avg_per_session,
+        }
+
+    async def get_session_stats(self, days: int | None = None) -> dict:
+        """
+        Get chat session statistics.
+
+        Args:
+            days: If provided, only include sessions from last N days
+
+        Returns:
+            Dictionary with session statistics
+        """
+        date_filter = None
+        if days is not None:
+            date_filter = datetime.now(timezone.utc) - timedelta(days=days)
+
+        # Total sessions
+        total_query = select(func.count()).select_from(ChatSession)
+        if date_filter:
+            total_query = total_query.where(ChatSession.created_at >= date_filter)
+        result = await self.session.execute(total_query)
+        total_sessions = result.scalar_one()
+
+        # Sessions active today (have messages today)
+        today_start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        result = await self.session.execute(
+            select(func.count(func.distinct(Message.session_id))).where(
+                Message.created_at >= today_start
+            )
+        )
+        active_today = result.scalar_one()
+
+        # Unique session owners
+        owners_query = select(func.count(func.distinct(ChatSession.user_id)))
+        if date_filter:
+            owners_query = owners_query.where(ChatSession.created_at >= date_filter)
+        result = await self.session.execute(owners_query)
+        unique_owners = result.scalar_one()
+
+        return {
+            "total_sessions": total_sessions,
+            "active_today": active_today,
+            "unique_owners": unique_owners,
+        }
+
+    async def get_all_stats(self, days: int | None = None) -> dict:
+        """
+        Get all statistics in a single call.
+
+        Args:
+            days: If provided, limit all stats to last N days
+
+        Returns:
+            Dictionary with all statistics grouped by category
+        """
+        return {
+            "user_counts": await self.get_user_counts(days),
+            "users_by_role": await self.get_users_by_role(days),
+            "top_active_users": await self.get_top_active_users(5, days),
+            "recent_users": await self.get_recent_users(5, days),
+            "message_stats": await self.get_message_stats(days),
+            "session_stats": await self.get_session_stats(days),
+            "filter_days": days,
+        }

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -427,3 +427,30 @@ def ci(c):
         print("✅ CI Passed")
         print("=" * 60)
         return True
+
+
+@task(name="db-stats")
+def db_stats(c, days=None):
+    """
+    Display database statistics.
+
+    Shows counts and metrics for users, sessions, and messages.
+    Useful for monitoring database health and user engagement.
+
+    Args:
+        days: Limit statistics to last N days (default: unlimited)
+
+    Usage:
+        invoke db-stats           # All-time statistics
+        invoke db-stats --days 7  # Last 7 days only
+
+    Production:
+        docker exec stupidbot-backend .venv/bin/python -m app.cli.stats
+    """
+    cmd = "python -m app.cli.stats"
+
+    if days:
+        cmd += f" --days {days}"
+
+    print("Fetching database statistics...")
+    c.run(cmd, pty=True)

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for Stupid Chat Bot backend."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,178 @@
+"""Pytest configuration and shared fixtures."""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models.base import Base
+from app.models.message import Message
+from app.models.session import ChatSession
+from app.models.user import User, UserRole
+
+
+@pytest.fixture(scope="session")
+def event_loop_policy():
+    """Use default event loop policy."""
+    import asyncio
+
+    return asyncio.DefaultEventLoopPolicy()
+
+
+@pytest_asyncio.fixture
+async def async_engine():
+    """Create an async engine for testing with in-memory SQLite."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        echo=False,
+        future=True,
+    )
+
+    # Enable foreign keys for SQLite
+    @event.listens_for(engine.sync_engine, "connect")
+    def set_sqlite_pragma(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    yield engine
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def async_session(async_engine) -> AsyncSession:
+    """Create an async session for testing."""
+    async_session_maker = async_sessionmaker(
+        async_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    async with async_session_maker() as session:
+        yield session
+
+
+@pytest_asyncio.fixture
+async def sample_users(async_session: AsyncSession) -> list[User]:
+    """Create sample users for testing."""
+    users = [
+        User(
+            id=uuid.uuid4(),
+            email="admin@example.com",
+            display_name="Admin User",
+            role=UserRole.ADMIN.value,
+            provider="email",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ),
+        User(
+            id=uuid.uuid4(),
+            email="user1@example.com",
+            display_name="User One",
+            role=UserRole.USER.value,
+            provider="google",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ),
+        User(
+            id=uuid.uuid4(),
+            email="user2@example.com",
+            display_name="User Two",
+            role=UserRole.USER.value,
+            provider="github",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ),
+    ]
+
+    for user in users:
+        async_session.add(user)
+    await async_session.commit()
+
+    return users
+
+
+@pytest_asyncio.fixture
+async def sample_sessions(async_session: AsyncSession) -> list[ChatSession]:
+    """Create sample chat sessions for testing."""
+    sessions = [
+        ChatSession(
+            id=uuid.uuid4(),
+            user_id=str(uuid.uuid4()),  # Anonymous user
+            title="Anonymous Session 1",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ),
+        ChatSession(
+            id=uuid.uuid4(),
+            user_id=str(uuid.uuid4()),  # Another anonymous user
+            title="Anonymous Session 2",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        ),
+    ]
+
+    for session in sessions:
+        async_session.add(session)
+    await async_session.commit()
+
+    return sessions
+
+
+@pytest_asyncio.fixture
+async def sample_messages(
+    async_session: AsyncSession, sample_users: list[User], sample_sessions: list[ChatSession]
+) -> list[Message]:
+    """Create sample messages for testing."""
+    messages = []
+
+    # Messages from registered user
+    for i in range(5):
+        msg = Message(
+            id=uuid.uuid4(),
+            session_id=sample_sessions[0].id,
+            user_id=sample_users[1].id,  # User One
+            sender="user",
+            content=f"User message {i}",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        messages.append(msg)
+        async_session.add(msg)
+
+        # Assistant response
+        assistant_msg = Message(
+            id=uuid.uuid4(),
+            session_id=sample_sessions[0].id,
+            user_id=None,
+            sender="assistant",
+            content=f"Assistant response {i}",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        messages.append(assistant_msg)
+        async_session.add(assistant_msg)
+
+    # Anonymous messages
+    for i in range(3):
+        msg = Message(
+            id=uuid.uuid4(),
+            session_id=sample_sessions[1].id,
+            user_id=None,  # Anonymous
+            sender="user",
+            content=f"Anonymous message {i}",
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        messages.append(msg)
+        async_session.add(msg)
+
+    await async_session.commit()
+    return messages

--- a/backend/tests/repositories/__init__.py
+++ b/backend/tests/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Repository tests."""

--- a/backend/tests/repositories/test_stats.py
+++ b/backend/tests/repositories/test_stats.py
@@ -1,0 +1,138 @@
+"""Tests for StatsRepository."""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.message import Message
+from app.models.session import ChatSession
+from app.models.user import User
+from app.repositories.stats import StatsRepository
+
+
+@pytest.mark.asyncio
+async def test_get_user_counts_empty_db(async_session: AsyncSession):
+    """Test user counts on empty database."""
+    repo = StatsRepository(async_session)
+    counts = await repo.get_user_counts()
+
+    assert counts["registered_users"] == 0
+    assert counts["unique_session_owners"] == 0
+    assert counts["total_chat_sessions"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_user_counts_with_data(
+    async_session: AsyncSession,
+    sample_users: list[User],
+    sample_sessions: list[ChatSession],
+):
+    """Test user counts with sample data."""
+    repo = StatsRepository(async_session)
+    counts = await repo.get_user_counts()
+
+    assert counts["registered_users"] == 3  # admin, user1, user2
+    assert counts["unique_session_owners"] == 2  # 2 anonymous sessions
+    assert counts["total_chat_sessions"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_users_by_role(async_session: AsyncSession, sample_users: list[User]):
+    """Test users grouped by role."""
+    repo = StatsRepository(async_session)
+    by_role = await repo.get_users_by_role()
+
+    role_counts = {r["role"]: r["count"] for r in by_role}
+    assert role_counts.get("admin") == 1
+    assert role_counts.get("user") == 2
+
+
+@pytest.mark.asyncio
+async def test_get_top_active_users(
+    async_session: AsyncSession,
+    sample_users: list[User],
+    sample_sessions: list[ChatSession],
+    sample_messages: list[Message],
+):
+    """Test top active users query."""
+    repo = StatsRepository(async_session)
+    top_users = await repo.get_top_active_users(limit=5)
+
+    # Should have at least one entry
+    assert len(top_users) > 0
+
+    # First user should be User One (5 messages)
+    assert top_users[0]["message_count"] == 5
+    assert top_users[0]["user_type"] == "registered"
+
+
+@pytest.mark.asyncio
+async def test_get_recent_users(async_session: AsyncSession, sample_users: list[User]):
+    """Test recent users query."""
+    repo = StatsRepository(async_session)
+    recent = await repo.get_recent_users(limit=5)
+
+    assert len(recent) == 3
+    # Should have email/display_name
+    for user in recent:
+        assert user["email"] is not None or user["display_name"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_message_stats(
+    async_session: AsyncSession,
+    sample_users: list[User],
+    sample_sessions: list[ChatSession],
+    sample_messages: list[Message],
+):
+    """Test message statistics."""
+    repo = StatsRepository(async_session)
+    stats = await repo.get_message_stats()
+
+    # 5 user messages from registered + 5 assistant + 3 anonymous = 13
+    assert stats["total_messages"] == 13
+    assert stats["user_messages"] == 8  # 5 registered + 3 anonymous
+    assert stats["assistant_messages"] == 5
+
+
+@pytest.mark.asyncio
+async def test_get_session_stats(
+    async_session: AsyncSession,
+    sample_sessions: list[ChatSession],
+    sample_messages: list[Message],
+):
+    """Test session statistics."""
+    repo = StatsRepository(async_session)
+    stats = await repo.get_session_stats()
+
+    assert stats["total_sessions"] == 2
+    assert stats["unique_owners"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_all_stats(
+    async_session: AsyncSession,
+    sample_users: list[User],
+    sample_sessions: list[ChatSession],
+    sample_messages: list[Message],
+):
+    """Test getting all stats at once."""
+    repo = StatsRepository(async_session)
+    all_stats = await repo.get_all_stats()
+
+    # Check all sections are present
+    assert "user_counts" in all_stats
+    assert "users_by_role" in all_stats
+    assert "top_active_users" in all_stats
+    assert "recent_users" in all_stats
+    assert "message_stats" in all_stats
+    assert "session_stats" in all_stats
+    assert all_stats["filter_days"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_all_stats_with_days_filter(async_session: AsyncSession):
+    """Test stats with days filter."""
+    repo = StatsRepository(async_session)
+    all_stats = await repo.get_all_stats(days=7)
+
+    assert all_stats["filter_days"] == 7

--- a/docs/AUTOMATED_DEPLOYMENT.md
+++ b/docs/AUTOMATED_DEPLOYMENT.md
@@ -18,6 +18,7 @@ This guide provides step-by-step instructions for setting up automated deploymen
 - [Troubleshooting](#troubleshooting)
 - [Rollback Procedures](#rollback-procedures)
 - [Monitoring](#monitoring)
+- [Database Monitoring](#database-monitoring)
 
 ---
 
@@ -575,6 +576,94 @@ curl https://stupidbot.dremdem.ru/api/sessions
    - Review GitHub Actions logs
    - Monitor deployment success rate
    - Set up uptime monitoring for production URL
+
+---
+
+## Database Monitoring
+
+### View Database Statistics
+
+The `db-stats` CLI command provides essential database metrics without requiring manual SQL queries.
+
+**Local Development:**
+```bash
+# Via make
+make backend-db-stats
+
+# Via invoke
+cd backend && invoke db-stats
+
+# With time filter (last 7 days)
+cd backend && invoke db-stats --days 7
+```
+
+**Production (Docker on DigitalOcean):**
+```bash
+# SSH to server and run stats
+ssh github-deploy@YOUR_DROPLET_IP
+
+# All-time statistics
+docker exec stupidbot-backend .venv/bin/python -m app.cli.stats
+
+# Last 30 days only
+docker exec stupidbot-backend .venv/bin/python -m app.cli.stats --days 30
+```
+
+**Sample Output:**
+```
+============================================================
+              DATABASE STATISTICS
+============================================================
+
+ USER COUNTS
+   Registered users:     12
+   Unique session owners:47
+   Total chat sessions:  59
+
+ USERS BY ROLE
+   user            8
+   anonymous       2
+   unlimited       1
+   admin           1
+
+ TOP 5 ACTIVE USERS (by messages)
+   1. john@example.com                142 msgs
+   2. Anonymous (78e88fc6...)          98 msgs [anon]
+   3. jane@example.com                 67 msgs
+   4. bob@example.com                  45 msgs
+   5. Anonymous (a1b2c3d4...)          32 msgs [anon]
+
+ LAST 5 REGISTERED USERS
+   1. alice@example.com           2024-12-25 14:30
+   2. bob@example.com             2024-12-24 10:15
+   3. charlie@example.com         2024-12-23 09:00
+   4. dave@example.com            2024-12-22 16:45
+   5. eve@example.com             2024-12-21 11:20
+
+ MESSAGE STATISTICS
+   Total messages:       847
+   User messages:        420
+   Assistant messages:   427
+   Messages today:       23
+   Avg per session:      14.4
+
+ SESSION STATISTICS
+   Total sessions:       59
+   Active today:         7
+   Unique owners:        47
+
+============================================================
+```
+
+**Available Metrics:**
+| Category | Metrics |
+|----------|---------|
+| User Counts | Registered users, unique session owners, total sessions |
+| Users by Role | Breakdown by role (anonymous, user, unlimited, admin) |
+| Top Active Users | Most messages sent (registered + anonymous) |
+| Recent Users | Last 5 registrations with date |
+| Message Stats | Total, by sender, today's count, avg per session |
+| Session Stats | Total sessions, active today, unique owners |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a new `db-stats` CLI command to display database metrics without requiring manual SQL queries.

**Closes #66**

### Features
- **User counts**: Registered users vs anonymous session owners
- **Users by role**: Breakdown by role (anonymous, user, unlimited, admin)
- **Top 5 active users**: Most messages sent (includes both registered and anonymous)
- **Last 5 registered users**: Recent registrations with timestamps
- **Message statistics**: Total, by sender type, today's count, avg per session
- **Session statistics**: Total sessions, active today, unique owners
- **Time filtering**: Optional `--days N` flag to limit stats to last N days

### Usage

**Local Development:**
```bash
make backend-db-stats              # All-time stats
cd backend && invoke db-stats      # Same
invoke db-stats --days 7           # Last 7 days only
```

**Production (Docker):**
```bash
docker exec stupidbot-backend .venv/bin/python -m app.cli.stats
docker exec stupidbot-backend .venv/bin/python -m app.cli.stats --days 30
```

### Files Changed
| File | Description |
|------|-------------|
| `backend/app/repositories/stats.py` | New StatsRepository with aggregate queries |
| `backend/app/cli/__init__.py` | CLI module init |
| `backend/app/cli/stats.py` | CLI tool with formatted output |
| `backend/tasks.py` | Added `db-stats` invoke task |
| `backend/tests/` | Test infrastructure + 9 tests for StatsRepository |
| `docs/AUTOMATED_DEPLOYMENT.md` | Production usage documentation |

### Sample Output
```
============================================================
              DATABASE STATISTICS
============================================================

 USER COUNTS
   Registered users:     1
   Unique session owners:2
   Total chat sessions:  3

 USERS BY ROLE
   user            1

 TOP 5 ACTIVE USERS (by messages)
   1. Anonymous (78e88fc6...)            8 msgs [anon]
   2. dremdem@gmail.com                  2 msgs

 LAST 5 REGISTERED USERS
   1. dremdem@gmail.com              2025-12-24 15:42

 MESSAGE STATISTICS
   Total messages:       20
   User messages:        10
   Assistant messages:   10
   Messages today:       0
   Avg per session:      20.0

 SESSION STATISTICS
   Total sessions:       3
   Active today:         0
   Unique owners:        2

============================================================
```

## Test plan
- [x] Run `invoke db-stats` locally - verified working
- [x] Run `invoke db-stats --days 7` - verified time filter works
- [x] Run pytest tests (9 tests pass)
- [x] Verify linting passes
- [ ] CI passes
- [ ] Test in Docker after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)