### PR TITLE
fix: exclude local .venv from Docker volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - CORS_ORIGINS=http://localhost:5173
     volumes:
       - ./backend:/app
+      - /app/.venv  # Exclude local .venv to prevent reload loops
     command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     networks:
       - chat-network


### PR DESCRIPTION
## Summary

Fixes the "Connecting..." issue in local development where the frontend couldn't establish WebSocket connection to the backend.

### Root Cause

When running `make dev`, the backend container was stuck in a **constant reload loop**:

```
WARNING:  WatchFiles detected changes in '.venv/lib/python3.12/site-packages/aiohttp/...'
INFO:     Shutting down
WARNING:  WatchFiles detected changes in '.venv/lib/python3.12/site-packages/httpcore/...'
[endless loop]
```

**Why this happened:**
1. `./backend:/app` volume mount included the local `.venv/` directory
2. `uvicorn --reload` watched ALL files in `/app`, including `.venv/site-packages/`
3. Any file activity (pip updates, IDE indexing) triggered container restarts
4. WebSocket connections couldn't establish due to constant backend restarts

### Solution

Add an anonymous volume that masks the local `.venv`:

```yaml
volumes:
  - ./backend:/app
  - /app/.venv  # NEW: Exclude local .venv to prevent reload loops
```

This is the same pattern used for the frontend's `node_modules`:
```yaml
volumes:
  - ./frontend:/app
  - /app/node_modules  # Masks local node_modules
```

### How It Works

| Before | After |
|--------|-------|
| Container uses local `.venv` (mounted) | Container uses its own `.venv` (from build) |
| Local pip changes trigger reloads | Local `.venv` is isolated |
| Backend constantly restarting | Backend stable |

### Testing

After merging:
```bash
docker compose down -v
docker compose up --build
```

The backend should start once and stay running. Frontend WebSocket should connect.

## Test plan
- [ ] Run `make dev` after `docker compose down -v`
- [ ] Verify backend doesn't show repeated "WatchFiles detected changes in .venv" messages
- [ ] Verify frontend connects (no more "Connecting..." stuck state)
- [ ] Verify hot reload still works for application code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)