### PR TITLE
fix: add missing await for OAuth authorization URL generation

### DIFF
--- a/backend/app/services/oauth_service.py
+++ b/backend/app/services/oauth_service.py
@@ -113,7 +113,7 @@ class OAuthService:
             return url["url"], url.get("state", state)
         else:
             # GitHub and Facebook use standard OAuth2
-            url = client.create_authorization_url(redirect_uri, state=state)
+            url = await client.create_authorization_url(redirect_uri, state=state)
             return url["url"], url.get("state", state)
 
     async def handle_callback(


### PR DESCRIPTION
## Summary

- Fixes GitHub and Facebook OAuth login which was failing with `TypeError: 'coroutine' object is not subscriptable`
- Added missing `await` keyword for `create_authorization_url` method call for non-Google OAuth providers
- The authlib `AsyncOAuth2Mixin.create_authorization_url` is async for all providers, not just Google

Fixes #71

## Test plan

- [ ] Test GitHub OAuth login flow - should redirect to GitHub authorization page
- [ ] Test Facebook OAuth login flow - should redirect to Facebook authorization page  
- [ ] Verify Google OAuth still works (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)