### PR TITLE
feat: add GitHub and Facebook OAuth secrets to deployment workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -144,6 +144,14 @@ jobs:
           GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
 
+          # OAuth (GitHub) - Using GH_ prefix because GITHUB_ is reserved by GitHub Actions
+          GH_CLIENT_ID=${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET=${{ secrets.GH_CLIENT_SECRET }}
+
+          # OAuth (Facebook)
+          FACEBOOK_CLIENT_ID=${{ secrets.FACEBOOK_CLIENT_ID }}
+          FACEBOOK_CLIENT_SECRET=${{ secrets.FACEBOOK_CLIENT_SECRET }}
+
           # JWT
           JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,5 +1,6 @@
 """Application configuration using pydantic-settings."""
 
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -37,8 +38,16 @@ class Settings(BaseSettings):
     # OAuth Configuration
     google_client_id: str = ""
     google_client_secret: str = ""
-    github_client_id: str = ""
-    github_client_secret: str = ""
+    # GitHub OAuth: Support both GITHUB_ and GH_ prefixes
+    # (GITHUB_ is reserved in GitHub Actions secrets)
+    github_client_id: str = Field(
+        default="",
+        validation_alias=AliasChoices("github_client_id", "gh_client_id"),
+    )
+    github_client_secret: str = Field(
+        default="",
+        validation_alias=AliasChoices("github_client_secret", "gh_client_secret"),
+    )
     facebook_client_id: str = ""
     facebook_client_secret: str = ""
 

--- a/docs/AUTOMATED_DEPLOYMENT.md
+++ b/docs/AUTOMATED_DEPLOYMENT.md
@@ -270,6 +270,17 @@ cat ~/.ssh/github-actions-stupidbot
 | `OPENAI_API_KEY` | OpenAI key (optional) | `sk-...` |
 | `GOOGLE_API_KEY` | Google key (optional) | |
 | `DEEPSEEK_API_KEY` | DeepSeek key (optional) | |
+| `GOOGLE_CLIENT_ID` | Google OAuth client ID (optional) | |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret (optional) | |
+| `GH_CLIENT_ID` | GitHub OAuth client ID (optional) | |
+| `GH_CLIENT_SECRET` | GitHub OAuth client secret (optional) | |
+| `FACEBOOK_CLIENT_ID` | Facebook OAuth client ID (optional) | |
+| `FACEBOOK_CLIENT_SECRET` | Facebook OAuth client secret (optional) | |
+| `JWT_SECRET_KEY` | JWT signing key | |
+| `BACKEND_URL` | Backend URL for OAuth callbacks | `https://stupidbot.dremdem.ru` |
+| `FRONTEND_URL` | Frontend URL for redirects | `https://stupidbot.dremdem.ru` |
+
+**Note:** GitHub reserves the `GITHUB_` prefix for its own secrets, so we use `GH_CLIENT_ID` and `GH_CLIENT_SECRET` instead.
 
 **Note:** `DO_HOST` and `DO_USER` will likely be the same as cv_profile's `DROPLET_HOST` and `DROPLET_USER`.
 

--- a/docs/oauth-setup-guide.md
+++ b/docs/oauth-setup-guide.md
@@ -80,10 +80,21 @@ GOOGLE_CLIENT_SECRET=your-client-secret
 
 ### Step 3: Add to Environment
 
+**Local development** (`.env` file):
 ```bash
 GITHUB_CLIENT_ID=your-client-id
 GITHUB_CLIENT_SECRET=your-client-secret
 ```
+
+**GitHub Actions secrets** (for production deployment):
+
+GitHub reserves the `GITHUB_` prefix, so use `GH_` instead:
+```
+GH_CLIENT_ID=your-client-id
+GH_CLIENT_SECRET=your-client-secret
+```
+
+The backend supports both prefixes automatically.
 
 ### Production Setup
 


### PR DESCRIPTION
## Summary

- Add GitHub OAuth secrets (`GH_CLIENT_ID`, `GH_CLIENT_SECRET`) to deployment workflow
- Add Facebook OAuth secrets (`FACEBOOK_CLIENT_ID`, `FACEBOOK_CLIENT_SECRET`) to deployment workflow
- Support both `GITHUB_` and `GH_` prefixes in backend config (GitHub reserves `GITHUB_` prefix)
- Update deployment documentation with all OAuth secrets
- Update OAuth setup guide with note about `GH_` prefix requirement

Fixes #73

## Changes

| File | Change |
|------|--------|
| `.github/workflows/docker-release.yml` | Add OAuth secrets to .env generation |
| `backend/app/config.py` | Support `GH_CLIENT_ID` as alias for `GITHUB_CLIENT_ID` |
| `docs/AUTOMATED_DEPLOYMENT.md` | Add OAuth secrets to required secrets table |
| `docs/oauth-setup-guide.md` | Document `GH_` prefix for GitHub Actions |

## Test plan

- [ ] CI passes
- [ ] After merge, add `GH_CLIENT_ID` and `GH_CLIENT_SECRET` to GitHub repo secrets
- [ ] Trigger deployment and verify GitHub OAuth works in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)