### PR TITLE
fix: properly detect unconfigured OAuth providers

### DIFF
--- a/backend/app/services/oauth_service.py
+++ b/backend/app/services/oauth_service.py
@@ -73,11 +73,10 @@ class OAuthService:
 
     def is_provider_configured(self, provider: str) -> bool:
         """Check if a provider is configured."""
-        try:
-            self.oauth.create_client(provider)
-            return True
-        except Exception:
-            return False
+        # Note: create_client() returns None for unregistered providers,
+        # it doesn't raise an exception
+        client = self.oauth.create_client(provider)
+        return client is not None
 
     def get_configured_providers(self) -> list[str]:
         """Get list of configured OAuth providers."""


### PR DESCRIPTION
## Summary

- Fix `is_provider_configured()` to properly detect when OAuth providers are not configured
- Returns proper 400 error instead of cryptic 500 error for unconfigured providers

Fixes #75

## Problem

The `is_provider_configured()` method was always returning `True` because authlib's `create_client()` returns `None` for unregistered providers instead of raising an exception:

```python
# Before (broken)
def is_provider_configured(self, provider: str) -> bool:
    try:
        self.oauth.create_client(provider)  # Returns None, doesn't raise
        return True  # Always True!
    except Exception:
        return False
```

## Solution

```python
# After (fixed)
def is_provider_configured(self, provider: str) -> bool:
    client = self.oauth.create_client(provider)
    return client is not None
```

## Before/After

| Scenario | Before | After |
|----------|--------|-------|
| Unconfigured provider | 500 `AttributeError: 'NoneType' object...` | 400 `Provider 'github' is not configured` |

## Test plan

- [ ] CI passes
- [ ] Test with unconfigured provider returns 400 error
- [ ] Test with configured provider works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)