### PR TITLE
docs: update secrets documentation with dual OAuth apps info

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,6 +38,10 @@ GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
 # GitHub OAuth (https://github.com/settings/developers)
+# Note: GitHub only allows ONE callback URL per OAuth App.
+# Create separate apps for dev (localhost) and prod (your-domain.com).
+# For GitHub Actions secrets, use GH_CLIENT_ID/GH_CLIENT_SECRET
+# (GITHUB_ prefix is reserved by GitHub). Backend supports both prefixes.
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
 

--- a/docs/AUTOMATED_DEPLOYMENT.md
+++ b/docs/AUTOMATED_DEPLOYMENT.md
@@ -282,6 +282,8 @@ cat ~/.ssh/github-actions-stupidbot
 
 **Note:** GitHub reserves the `GITHUB_` prefix for its own secrets, so we use `GH_CLIENT_ID` and `GH_CLIENT_SECRET` instead.
 
+**Important:** GitHub OAuth Apps only support ONE callback URL. You need **separate OAuth Apps** for development (localhost) and production. The `GH_CLIENT_ID` and `GH_CLIENT_SECRET` secrets should be from your **production** OAuth App. See [OAuth Setup Guide](./oauth-setup-guide.md#github-two-oauth-apps-required) for details.
+
 **Note:** `DO_HOST` and `DO_USER` will likely be the same as cv_profile's `DROPLET_HOST` and `DROPLET_USER`.
 
 **If you generated a new SSH key:**


### PR DESCRIPTION
## Summary

Updates secrets documentation to clarify OAuth setup requirements, particularly the need for **two separate GitHub OAuth Apps** (dev and prod).

Fixes #67

## Changes

### New Section: Development vs Production OAuth
- Explains why different callback URLs are needed for dev/prod
- Table comparing provider behaviors (Google/Facebook allow multiple URLs, GitHub doesn't)
- Mermaid diagram showing the two-app setup for GitHub

### Updated GitHub OAuth Section
- Clear steps for creating **Development** OAuth App (localhost callback)
- Clear steps for creating **Production** OAuth App (domain callback)
- Summary table showing which credentials go where
- Note about `GH_` prefix requirement for GitHub Actions secrets

### Cross-References
- Added reference to `backend/.env.example` as authoritative source
- Added links between oauth-setup-guide.md and AUTOMATED_DEPLOYMENT.md
- Updated .env.example with comments about dual OAuth apps

## Files Changed

| File | Change |
|------|--------|
| `docs/oauth-setup-guide.md` | Added "Dev vs Prod OAuth" section, updated GitHub setup |
| `docs/AUTOMATED_DEPLOYMENT.md` | Added note about separate OAuth apps |
| `backend/.env.example` | Added comments about GH_ prefix and dual apps |

## Test plan

- [ ] Review rendered markdown on GitHub
- [ ] Verify mermaid diagram renders correctly
- [ ] Check all internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)