### PR TITLE
fix: fix session persistence - correct cookie path and add periodic refresh

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -178,7 +178,7 @@ async def register(
         httponly=COOKIE_HTTPONLY,
         secure=COOKIE_SECURE,
         samesite=COOKIE_SAMESITE,
-        path="/auth",
+        path="/api/auth",
     )
 
     return TokenResponse(
@@ -243,7 +243,7 @@ async def login(
         httponly=COOKIE_HTTPONLY,
         secure=COOKIE_SECURE,
         samesite=COOKIE_SAMESITE,
-        path="/auth",
+        path="/api/auth",
     )
 
     return TokenResponse(
@@ -380,7 +380,7 @@ async def oauth_callback(
         httponly=COOKIE_HTTPONLY,
         secure=COOKIE_SECURE,
         samesite=COOKIE_SAMESITE,
-        path="/auth",  # Only sent to auth endpoints
+        path="/api/auth",  # Only sent to auth endpoints
     )
 
     return response
@@ -414,7 +414,7 @@ async def refresh_tokens(
     if not result:
         # Clear invalid cookies
         response.delete_cookie("access_token")
-        response.delete_cookie("refresh_token", path="/auth")
+        response.delete_cookie("refresh_token", path="/api/auth")
         raise HTTPException(status_code=401, detail="Invalid or expired refresh token")
 
     new_access_token, new_refresh_token = result
@@ -440,7 +440,7 @@ async def refresh_tokens(
         httponly=COOKIE_HTTPONLY,
         secure=COOKIE_SECURE,
         samesite=COOKIE_SAMESITE,
-        path="/auth",
+        path="/api/auth",
     )
 
     return TokenResponse(
@@ -465,6 +465,6 @@ async def logout(
 
     # Clear cookies
     response.delete_cookie("access_token")
-    response.delete_cookie("refresh_token", path="/auth")
+    response.delete_cookie("refresh_token", path="/api/auth")
 
     return {"message": "Logged out successfully"}


### PR DESCRIPTION
## Summary

Fixes the issue where users need to re-authenticate every time they visit the app.

## Root Cause

The `refresh_token` cookie was set with `path="/auth"` but the refresh endpoint is at `/api/auth/refresh`. 

```
Cookie path: /auth
Refresh endpoint: /api/auth/refresh  ← doesn't match!
```

The browser never sent the refresh token to the refresh endpoint, causing all refresh attempts to fail silently.

## Changes

### 1. Backend - Cookie Path Fix (`backend/app/api/auth.py`)

Changed cookie path from `/auth` to `/api/auth` in 6 locations:

| Location | Line |
|----------|------|
| Register endpoint | 181 |
| Login endpoint | 246 |
| OAuth callback | 383 |
| Refresh endpoint (set) | 443 |
| Refresh endpoint (delete) | 417 |
| Logout endpoint | 468 |

### 2. Frontend - Periodic Token Refresh (`frontend/src/contexts/AuthContext.jsx`)

Added automatic token refresh every 25 minutes (5 minutes before access token expires):

- New `TOKEN_REFRESH_INTERVAL` constant (25 min)
- `useEffect` that sets up interval when authenticated
- Interval cleared on logout or unmount
- Graceful error handling (doesn't logout on network errors)

## Test Plan

1. **Session persistence test**:
   - [ ] Login → close browser → reopen → should stay logged in
   - [ ] Login → close tab → reopen → should stay logged in
   - [ ] Check browser cookies: `refresh_token` should have path `/api/auth`

2. **Periodic refresh test**:
   - [ ] Login → wait 25+ minutes → should still be logged in
   - [ ] Check network tab: `/api/auth/refresh` called every 25 min

3. **Logout test**:
   - [ ] Logout → both cookies cleared
   - [ ] Refresh interval stopped

Fixes #81
Ref: #79 (Authentication menu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)